### PR TITLE
Use correct text code size

### DIFF
--- a/MagikoopaUI/patchmaker.cpp
+++ b/MagikoopaUI/patchmaker.cpp
@@ -299,14 +299,15 @@ void PatchMaker::insert()
     delete newCodeFile;
 
     emit updateStatus("Fixing Exheader");
-    fixExheader(loaderDataEnd + m_hookLinker.extraDataSize() - m_newCodeOffset);
+    quint32 newTextCodeSize = loaderTextEnd + m_loaderHookLinker.extraDataSize() - 0x100000;
+    fixExheader(loaderDataEnd + m_hookLinker.extraDataSize() - m_newCodeOffset, newTextCodeSize);
 }
 
-void PatchMaker::fixExheader(quint32 newCodeSize)
+void PatchMaker::fixExheader(quint32 newCodeSize, quint32 newTextCodeSize)
 {
     Exheader exHeader(new ExternalFile(m_path + "/exheader.bin"));
 
-    exHeader.data.sci.textCodeSetInfo.size = exHeader.data.sci.textCodeSetInfo.physicalRegionSize << 12;
+    exHeader.data.sci.textCodeSetInfo.size = newTextCodeSize;
 
     qDebug() << QString("Data size: %1").arg(exHeader.data.sci.dataCodeSetInfo.physicalRegionSize << 12, 8, 0x10, QChar('0')).toLatin1().data();;
     qDebug() << QString("BSS size: %1").arg(((exHeader.data.sci.bssSize + 0xFFF) & ~0xFFF), 8, 0x10, QChar('0')).toLatin1().data();;

--- a/MagikoopaUI/patchmaker.h
+++ b/MagikoopaUI/patchmaker.h
@@ -46,7 +46,7 @@ private:
     void restoreFromBackup();
 
     void insert();
-    void fixExheader(quint32 newCodeSize);
+    void fixExheader(quint32 newCodeSize, quint32 newTextCodeSize);
     void postHook();
     void allDone();
 


### PR DESCRIPTION
The text code set info used an aligned value as size before, however I had to use the exact size because otherwise it was working fine on citra but crashing on real hardware with Luma3DS.

With the changes I did it works on both systems (but I have no idea what I'm doing :) )